### PR TITLE
fix bug: lfu find min value in tmpFreq array(not in physicalFrames)

### DIFF
--- a/source/MemoryManager .cpp
+++ b/source/MemoryManager .cpp
@@ -785,7 +785,7 @@ static void simulateLFU(int physicalFramesNum)
 
 				for (int j = 1; j < physicalFramesNum; j++)
 				{
-					if (usageFreq[physicalFrames[j]] < usageFreq[LFU])
+					if (usageFreq[tmpFrames[j]] < usageFreq[LFU])
 					{
 						LFU      = tmpFrames[j];
 						position = j;


### PR DESCRIPTION
At Issue #1 